### PR TITLE
Add Python wrapper, package and example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+#Python files
+*.pyc
+python/msrl.egg-info/*

--- a/python/example.py
+++ b/python/example.py
@@ -1,0 +1,11 @@
+import numpy as np
+from msrl import MSRL_cv
+
+n, p, q = 20, 30, 10
+
+np.random.seed(18)
+X = np.random.randn(n, p)
+Y = np.random.randn(n, q)
+
+betas, lambdas, sparsity = MSRL_cv(X, Y, nlambda=10, tol=1e-12)
+print(betas.shape)

--- a/python/msrl/__init__.py
+++ b/python/msrl/__init__.py
@@ -1,0 +1,1 @@
+from .wrapper import MSRL_cv

--- a/python/msrl/wrapper.py
+++ b/python/msrl/wrapper.py
@@ -1,0 +1,23 @@
+import numpy as np
+from rpy2 import robjects
+import rpy2.robjects.packages as rpackages
+from rpy2.robjects import numpy2ri, pandas2ri
+
+numpy2ri.activate()
+pandas2ri.activate()
+msrl = rpackages.importr("MSRL")
+
+
+def MSRL_cv(X, Y, nlambda, tol, quiet=False):
+    msrl_fit = msrl.MSRL_cv(X=X, Y=Y, nlambda=nlambda, tol=tol, quiet=quiet)
+    n, p = X.shape
+    q = Y.shape[1]
+    fit_dict = dict(zip(msrl_fit.names, list(msrl_fit)))
+
+    as_matrix = robjects.r['as']
+    betas = np.array(as_matrix(fit_dict["beta"], "matrix"))
+    betas = np.array([beta.reshape((p, q), order='F') for beta in betas.T])
+    sparsity = np.array(fit_dict["sparsity.mat"])
+    lambdas = np.array(fit_dict["lambda.vec"])
+
+    return betas, lambdas, sparsity

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,3 @@
+rpy2
+numpy
+pandas

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,23 @@
+# from rpy2 import robjects
+from setuptools import setup
+import rpy2.robjects.packages as rpackages
+
+
+utils = rpackages.importr('utils')
+utils.chooseCRANmirror(ind=1)
+# installing devtools may take a while the first time (10 miutes)
+if not rpackages.isinstalled("MSRL"):
+    if not rpackages.isinstalled('devtools'):
+        utils.install_packages("devtools")
+    devtools = rpackages.importr('devtools')
+    devtools.install_github("ajmolstad/MSRL")
+
+desc = "Perform cross-validation, prediction, and extract coefficients from" \
+    "fitted models for the multivariate square-root lasso."
+
+setup(
+    name="msrl",
+    version='0.1',
+    description=desc,
+    author_email="amolstad@ufl.edu"
+)


### PR DESCRIPTION
Hello @ajmolstad 

This PR implements a rough python wrapper, and a module structure so that the code can be executed everywhere.
It calls the R module, so maintenance should be minimal.

You can pip install the requirements first (being in the `python` folder):
`pip install requirements.txt`

then install the module
`pip install -e .`

the execute `example.py` to check that it runs as desired.

Keep me posted if you have feedback.
Mathurin